### PR TITLE
Add Pure Data sample patches and idea tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- For every change to this repository, add one new original Pure Data sample patch.
+- Choose the first idea from `IDEAS_OF_PD_SAMPLES.md`, implement it under `res/patches/samples/`, then remove that idea from the file.
+- After removing an idea, append a new idea to the end of `IDEAS_OF_PD_SAMPLES.md`.
+- Keep patches self-contained and clearly named.

--- a/IDEAS_OF_PD_SAMPLES.md
+++ b/IDEAS_OF_PD_SAMPLES.md
@@ -1,0 +1,5 @@
+# PD Sample Ideas
+
+- granular delay effect
+- sample-based looper
+- bitcrusher with LFO

--- a/res/patches/samples/noise_filter.pd
+++ b/res/patches/samples/noise_filter.pd
@@ -1,0 +1,13 @@
+#N canvas 100 100 450 300 10;
+#X obj 100 50 noise~;
+#X obj 100 100 lop~ 800;
+#X floatatom 180 70 5 0 0 0 - - -;
+#X obj 180 90 sig~;
+#X obj 100 150 *~ 0.2;
+#X obj 100 200 dac~;
+#X connect 0 0 1 0;
+#X connect 1 0 4 0;
+#X connect 2 0 3 0;
+#X connect 3 0 1 1;
+#X connect 4 0 5 0;
+#X connect 4 0 5 1;

--- a/res/patches/samples/random_melody.pd
+++ b/res/patches/samples/random_melody.pd
@@ -1,0 +1,17 @@
+#N canvas 100 100 500 400 10;
+#X obj 50 50 loadbang;
+#X obj 50 80 metro 500;
+#X obj 50 110 random 12;
+#X obj 50 140 + 60;
+#X obj 50 170 mtof;
+#X obj 50 200 osc~;
+#X obj 50 230 *~ 0.2;
+#X obj 50 260 dac~;
+#X connect 0 0 1 0;
+#X connect 1 0 2 0;
+#X connect 2 0 3 0;
+#X connect 3 0 4 0;
+#X connect 4 0 5 0;
+#X connect 5 0 6 0;
+#X connect 6 0 7 0;
+#X connect 6 0 7 1;

--- a/res/patches/samples/sine_oscillator.pd
+++ b/res/patches/samples/sine_oscillator.pd
@@ -1,0 +1,7 @@
+#N canvas 72 50 450 300 10;
+#X obj 100 100 osc~ 440;
+#X floatatom 100 50 5 0 0 0 - - -;
+#X obj 100 150 dac~;
+#X connect 0 0 2 0;
+#X connect 0 0 2 1;
+#X connect 1 0 0 0;


### PR DESCRIPTION
## Summary
- introduce AGENTS guidelines enforcing addition of Pure Data sample patch and idea maintenance
- track future patch concepts in IDEAS_OF_PD_SAMPLES.md
- add three new sample patches: sine oscillator, noise filter, and random melody

## Testing
- `pd -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7837073483269a267f75fd74814f