### PR TITLE
feat: make console draggable overlay

### DIFF
--- a/src/ConsoleViewController.h
+++ b/src/ConsoleViewController.h
@@ -13,6 +13,9 @@
 /// modal console log text view, uses Log textViewLogger
 @interface ConsoleViewController : UIViewController
 
+/// container view housing the console, draggable
+@property (strong, nonatomic) UIView *containerView;
+
 /// text view to display current log lines
 @property (strong, nonatomic) UITextView *textView;
 

--- a/src/ConsoleViewController.m
+++ b/src/ConsoleViewController.m
@@ -8,6 +8,7 @@
  * See https://github.com/danomatika/PdParty for documentation
  *
  */
+
 #import "ConsoleViewController.h"
 
 #import "Log.h"
@@ -19,54 +20,58 @@
 @implementation ConsoleViewController
 
 - (void)viewDidLoad {
-	[super viewDidLoad];
-	
-	// set size in iPad popup
-//	if(Util.isDeviceATablet) {
-//		self.preferredContentSize = CGSizeMake(320.0, 600.0);
-//	}
-	
-	// do not extend under nav bar
-	self.edgesForExtendedLayout = UIRectEdgeNone;
-	
-	self.textView = [[UITextView alloc] initWithFrame:CGRectZero];
-	self.textView.scrollEnabled = YES;
-	self.textView.showsVerticalScrollIndicator = YES;
-	self.textView.editable = NO;
-	self.textView.bounces = NO;
-	self.textView.font = [UIFont fontWithName:GUI_FONT_NAME size:12];
-	self.textView.minimumZoomScale = self.textView.maximumZoomScale; // no zooming
-	self.textView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-	
-	[self.view addSubview:self.textView];
-	self.textView.translatesAutoresizingMaskIntoConstraints = NO;
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[view]|"
-	                                                                  options:0
-	                                                                  metrics:nil
-	                                                                    views:@{@"view" : self.textView}]];
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[view]|"
-	                                                                  options:0
-	                                                                  metrics:nil
-	                                                                    views:@{@"view" : self.textView}]];
+        [super viewDidLoad];
 
-	self.navigationItem.title = @"Console";
-	self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(donePressed:)];
+        // transparent overlay
+        self.view.backgroundColor = UIColor.clearColor;
 
-	// opaque nav bar if content is scrollable
-	if(@available(iOS 13.0, *)) {
-		self.navigationController.navigationBar.scrollEdgeAppearance =
-			self.navigationController.navigationBar.standardAppearance;
-	}
+        // console container
+        self.containerView = [[UIView alloc] initWithFrame:CGRectZero];
+        self.containerView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
+        [self.view addSubview:self.containerView];
+
+        // allow dragging
+        UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+        [self.containerView addGestureRecognizer:pan];
+
+        // text view
+        self.textView = [[UITextView alloc] initWithFrame:self.containerView.bounds];
+        self.textView.scrollEnabled = YES;
+        self.textView.showsVerticalScrollIndicator = YES;
+        self.textView.editable = NO;
+        self.textView.bounces = NO;
+        self.textView.font = [UIFont fontWithName:GUI_FONT_NAME size:12];
+        self.textView.minimumZoomScale = self.textView.maximumZoomScale; // no zooming
+        self.textView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        self.textView.backgroundColor = UIColor.clearColor;
+        self.textView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        [self.containerView addSubview:self.textView];
+
+        // close button
+        UIButton *close = [UIButton buttonWithType:UIButtonTypeSystem];
+        [close setTitle:@"Done" forState:UIControlStateNormal];
+        [close addTarget:self action:@selector(donePressed:) forControlEvents:UIControlEventTouchUpInside];
+        close.frame = CGRectMake(self.containerView.bounds.size.width-60, 0, 60, 30);
+        close.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
+        [self.containerView addSubview:close];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-	Log.textViewLogger.textView = self.textView;
-	[super viewWillAppear:animated];
+        Log.textViewLogger.textView = self.textView;
+        [super viewWillAppear:animated];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
-	[super viewDidDisappear:animated];
-	Log.textViewLogger.textView = nil;
+        [super viewDidDisappear:animated];
+        Log.textViewLogger.textView = nil;
+}
+
+- (void)viewDidLayoutSubviews {
+        [super viewDidLayoutSubviews];
+        if(CGRectEqualToRect(self.containerView.frame, CGRectZero)) {
+                CGFloat width = self.view.bounds.size.width/2.0;
+                self.containerView.frame = CGRectMake(self.view.bounds.size.width - width, 0, width, self.view.bounds.size.height);
+        }
 }
 
 // update the scenemanager if there are rotations while the PatchView is hidden
@@ -74,25 +79,33 @@
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {}
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-		AppDelegate *app = (AppDelegate *)UIApplication.sharedApplication.delegate;
-		app.sceneManager.currentOrientation = UIApplication.sharedApplication.statusBarOrientation;
-	}];
-	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+                AppDelegate *app = (AppDelegate *)UIApplication.sharedApplication.delegate;
+                app.sceneManager.currentOrientation = UIApplication.sharedApplication.statusBarOrientation;
+        }];
+        [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 }
 
 // lock to orientations allowed by the current scene
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-	AppDelegate *app = (AppDelegate *)UIApplication.sharedApplication.delegate;
-	if(app.sceneManager.scene && !app.sceneManager.isRotated) {
-		return app.sceneManager.scene.preferredOrientations;
-	}
-	return UIInterfaceOrientationMaskAll;
+        AppDelegate *app = (AppDelegate *)UIApplication.sharedApplication.delegate;
+        if(app.sceneManager.scene && !app.sceneManager.isRotated) {
+                return app.sceneManager.scene.preferredOrientations;
+        }
+        return UIInterfaceOrientationMaskAll;
 }
 
 #pragma mark UI
 
 - (void)donePressed:(id)sender {
-	[self.navigationController dismissViewControllerAnimated:YES completion:nil];
+        [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)handlePan:(UIPanGestureRecognizer *)gesture {
+        UIView *piece = gesture.view;
+        CGPoint translation = [gesture translationInView:self.view];
+        piece.center = CGPointMake(piece.center.x + translation.x, piece.center.y + translation.y);
+        [gesture setTranslation:CGPointZero inView:self.view];
 }
 
 @end
+

--- a/src/MenuViewController.m
+++ b/src/MenuViewController.m
@@ -268,11 +268,9 @@
 - (void)showConsolePressed:(id)sender {
 	LogVerbose(@"Menu: show console button pressed");
 	[self.popover dismissPopoverAnimated:YES];
-	ConsoleViewController *consoleView = [[ConsoleViewController alloc] init];
-	UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:consoleView];
-	navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-	navigationController.modalInPopover = YES;
-	[self.popover.sourceController.navigationController presentViewController:navigationController animated:YES completion:nil];
+        ConsoleViewController *consoleView = [[ConsoleViewController alloc] init];
+        consoleView.modalPresentationStyle = UIModalPresentationOverFullScreen;
+        [self.popover.sourceController.navigationController presentViewController:consoleView animated:YES completion:nil];
 }
 
 - (void)showInfoPressed:(id)sender {


### PR DESCRIPTION
## Summary
- Make console a semi-transparent overlay with draggable container
- Expose console container view property
- Present console directly over the current view instead of form sheet

## Testing
- `xcodebuild -list -project PdParty.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e77e8fd0083269b21cc738de1fd0f