### PR TITLE
Add swipe-down button to reveal auto-hidden navigation bar

### DIFF
--- a/src/NavigationController.m
+++ b/src/NavigationController.m
@@ -10,18 +10,59 @@
  */
 #import "NavigationController.h"
 
-@implementation NavigationController
+@implementation NavigationController {
+        UIButton *_revealButton;
+}
+
+- (void)viewDidLoad {
+        [super viewDidLoad];
+
+        // start with the bar hidden
+        [self setNavigationBarHidden:YES animated:NO];
+
+        // semi transparent button to reveal the bar
+        _revealButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        _revealButton.frame = CGRectMake((self.view.bounds.size.width-60)/2.0, 0, 60, 20);
+        _revealButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin|
+                                        UIViewAutoresizingFlexibleRightMargin|
+                                        UIViewAutoresizingFlexibleBottomMargin;
+        _revealButton.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
+        _revealButton.alpha = 0.5;
+        [_revealButton setTitle:@"\u25BC" forState:UIControlStateNormal];
+        [self.view addSubview:_revealButton];
+
+        UISwipeGestureRecognizer *swipe = [[UISwipeGestureRecognizer alloc]
+                                           initWithTarget:self
+                                           action:@selector(revealSwipe:)];
+        swipe.direction = UISwipeGestureRecognizerDirectionDown;
+        [_revealButton addGestureRecognizer:swipe];
+}
+
+- (void)revealSwipe:(UISwipeGestureRecognizer *)recognizer {
+        if(recognizer.state == UIGestureRecognizerStateEnded) {
+                [self setNavigationBarHidden:NO animated:YES];
+                _revealButton.hidden = YES;
+
+                // auto hide again after a short delay
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                             (int64_t)(3 * NSEC_PER_SEC)),
+                               dispatch_get_main_queue(), ^{
+                        [self setNavigationBarHidden:YES animated:YES];
+                        _revealButton.hidden = NO;
+                });
+        }
+}
 
 - (BOOL)shouldAutorotate {
-	return self.topViewController.shouldAutorotate;
+        return self.topViewController.shouldAutorotate;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-	return self.topViewController.supportedInterfaceOrientations;
+        return self.topViewController.supportedInterfaceOrientations;
 }
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
-	return self.topViewController.preferredInterfaceOrientationForPresentation;
+        return self.topViewController.preferredInterfaceOrientationForPresentation;
 }
 
 @end


### PR DESCRIPTION
## Summary
- Hide navigation bar by default and overlay a semi-transparent button
- Reveal navigation bar via swipe-down gesture and auto-hide after delay
- Keep overlay button positioned at top during rotation

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7866543c83269c9e3a1ce9958743